### PR TITLE
Add support for Blade templates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "wp-cli-package",
     "homepage": "https://github.com/roborourke/wp-l10n-gen",
     "require": {
-        "gettext/gettext": "dev-master",
+        "gettext/gettext": "~4.8",
         "php": ">=5.4"
     },
     "license": "GPL-3.0",

--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -107,7 +107,13 @@ class Command extends WP_CLI_Command {
 				if ( isset( $assoc_args['verbose'] ) ) {
 					WP_CLI::log( sprintf( 'Extracting strings from %s', $file_path ) );
 				}
-				$translations->addFromWPCodeFile( $file_path );
+
+				if (stristr($file_path, '.blade.php') !== false) {
+					$translations->addFromWPCodeBladeFile( $file_path );
+				} else {
+					$translations->addFromWPCodeFile( $file_path );
+				}
+				
 				$progress->tick();
 			}
 

--- a/inc/class-wpcodeblade-extractor.php
+++ b/inc/class-wpcodeblade-extractor.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Gettext\Extractors;
+
+use Gettext\Extractors\WPCode;
+use Gettext\Translations;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\View\Compilers\BladeCompiler;
+
+class WPCodeBlade extends WPCode implements ExtractorInterface {
+
+	public static function fromString( $string, Translations $translations, array $options = [] ) {
+		
+		if (empty($options['facade'])) {
+			$cachePath = empty($options['cachePath']) ? sys_get_temp_dir() : $options['cachePath'];
+			$bladeCompiler = new BladeCompiler(new Filesystem(), $cachePath);
+			$string = $bladeCompiler->compileString($string);
+		} else {
+			$string = $options['facade']::compileString($string);
+		}
+
+		parent::fromString($string, $translations, $options);
+	}
+
+}

--- a/inc/class-wpfunctionsscanner.php
+++ b/inc/class-wpfunctionsscanner.php
@@ -14,7 +14,7 @@ class WPFunctionsScanner extends PhpFunctionsScanner {
 	 * @param array        $options      The extractor options
 	 * @throws Exception
 	 */
-	public function saveGettextFunctions( Translations $translations, array $options ) {
+	public function saveGettextFunctions( $translations, array $options ) {
 		$functions = $options['functions'];
 		$file      = $options['file'];
 

--- a/wp-l10n-gen.php
+++ b/wp-l10n-gen.php
@@ -23,6 +23,7 @@ if ( file_exists( 'vendor/autoload.php' ) ) {
 require_once 'inc/class-multi-filter.php';
 require_once 'inc/class-wpfunctionsscanner.php';
 require_once 'inc/class-wpcode-extractor.php';
+require_once 'inc/class-wpcodeblade-extractor.php';
 require_once 'inc/class-command.php';
 
 WP_CLI::add_command( 'l10n', __NAMESPACE__ . '\Command' );


### PR DESCRIPTION
Added a quick & dirty solution to support Blade templates. 

`WPCodeBlade::fromString()` contents are copy-paste from Gettext's own Blade extractor. 